### PR TITLE
feat: determine the default branch automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,8 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -236,6 +238,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
@@ -558,6 +566,43 @@ dependencies = [
  "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "serde"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+dependencies = [
+ "proc-macro2 1.0.42",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ clap = { version = "=3.2.16", features = ["cargo", "derive"] }
 git2 = { version = "=0.15.0", default-features = false, features = ["zlib-ng-compat"] }
 lazy_static = "=1.4.0"
 regex = "=1.6.0"
+serde = { version = "=1.0.143", features = ["derive"] }
+serde_json = "=1.0.83"
 
 [dev-dependencies]
 proptest = "=1.0.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,9 +1,10 @@
 use clap::{crate_version, Parser};
 
+use crate::default_branch::DefaultBranch;
+
 #[derive(Parser)]
 #[clap(name = "git-disjoint", version = crate_version!(), author = "Eric Crosson <eric.s.crosson@utexas.edu>")]
 pub(crate) struct Args {
-    // TODO: discuss defaulting to the last merge commit?
-    #[clap(value_parser)]
-    pub(crate) start_point: String,
+    #[clap(short, long)]
+    pub(crate) since: Option<DefaultBranch>,
 }

--- a/src/default_branch.rs
+++ b/src/default_branch.rs
@@ -1,0 +1,43 @@
+use std::{process::Command, str::FromStr};
+
+use anyhow::{Error, Result};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Repos {
+    default_branch: String,
+}
+
+// DISCUSS: how can we downshift to a String automatically?
+pub(crate) struct DefaultBranch(pub(crate) String);
+
+impl From<String> for DefaultBranch {
+    fn from(string: String) -> Self {
+        DefaultBranch(string)
+    }
+}
+
+impl FromStr for DefaultBranch {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        Ok(Self(string.to_owned()))
+    }
+}
+
+impl DefaultBranch {
+    pub(crate) fn try_get_default() -> Result<DefaultBranch> {
+        // hub api /repos/{owner}/{repo}
+        let stdout = String::from_utf8(
+            Command::new("hub")
+                .arg("api")
+                .arg("/repos/{owner}/{repo}")
+                .output()?
+                .stdout,
+        )?;
+
+        let repos: Repos = serde_json::from_str(&stdout)?;
+
+        Ok(repos.default_branch.into())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ use crate::sanitize_git_branch_name::sanitize_text_for_git_branch_name;
 // What if we stored a log of what we were going to do before we took any action?
 // Or kept it as a list of things to do, removing successful items.
 // TODO: add documentation
-// TODO: semantic-release to cargo
 
 #[derive(Debug)]
 struct PullRequestContent<'a> {


### PR DESCRIPTION
- rename `start_point` to `since`
- allow `since` to be defined with `--since` option
- default `since` to the repository's default branch