### PR TITLE
fix: support all GitHub comment keywords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "anyhow",
  "clap",
  "git2",
+ "indoc",
  "lazy_static",
  "proptest",
  "proptest-derive",
@@ -230,6 +231,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "indoc"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 
 [[package]]
 name = "instant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "=1.0.145", features = ["derive"] }
 serde_json = "=1.0.85"
 
 [dev-dependencies]
+indoc = "1.0.7"
 proptest = "=1.0.0"
 proptest-derive = "=0.3.0"
 


### PR DESCRIPTION
Closes #33