### PR TITLE
feat: support the fork model

### DIFF
--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -1,0 +1,19 @@
+use std::collections::HashSet;
+
+use anyhow::{anyhow, Result};
+use git2::Repository;
+
+pub(crate) struct UserConfig {
+    pub remote: String,
+}
+
+pub(crate) fn get_user_remote(repo: &Repository) -> Result<String> {
+    let repo_remotes = repo.remotes()?;
+    let mut remotes: HashSet<&str> = repo_remotes.iter().filter_map(|remote| remote).collect();
+
+    remotes
+        .take("fork")
+        .or_else(|| remotes.take("origin"))
+        .map(|str| str.to_owned())
+        .ok_or_else(|| anyhow!("Unable to choose a git remote to push to, expected to find a remote named 'fork' or 'origin'"))
+}


### PR DESCRIPTION
It's rough -- it requires the fork's remote to be named `fork`.

Maybe in the future we'll pull this from a configuration somewhere? But for now -- ship it.
