### PR TITLE
chore: use deny_docs

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use clap::{crate_version, Parser};
 
 use crate::default_branch::DefaultBranch;


### PR DESCRIPTION
to catch missing `--help` documentation at compile time :tada:

Ticket: 1