### PR TITLE
feat!: add --separate option

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -13,7 +13,7 @@ use crate::default_branch::DefaultBranch;
 pub(crate) struct Args {
     /// The lower-bound (exclusive) of commits to act on
     #[clap(short, long)]
-    pub since: Option<DefaultBranch>,
+    pub base: Option<DefaultBranch>,
 
     /// Prompt the user to select which issues to create PRs for
     #[clap(short, long, action)]
@@ -22,12 +22,17 @@ pub(crate) struct Args {
     /// Create a branch for all commits, even without an associated issue
     #[clap(short, long, action)]
     pub all: bool,
+
+    /// Treat every commit separately; do not group by ticket
+    #[clap(short, long, action)]
+    pub separate: bool,
 }
 
 pub(crate) struct SanitizedArgs {
-    pub since: DefaultBranch,
+    pub base: DefaultBranch,
     pub choose: bool,
     pub all: bool,
+    pub separate: bool,
 }
 
 impl SanitizedArgs {
@@ -40,16 +45,22 @@ impl TryFrom<Args> for SanitizedArgs {
     type Error = anyhow::Error;
 
     fn try_from(value: Args) -> Result<Self, Self::Error> {
-        let Args { since, choose, all } = value;
+        let Args {
+            base,
+            choose,
+            all,
+            separate,
+        } = value;
         Ok(Self {
             // Clap doesn't provide a way to supply a default value coming from
             // a function when the user has not supplied a required value.
             // This TryFrom bridges the gap.
-            since: since
+            base: base
                 .ok_or_else(|| anyhow!("User has not provided a default branch"))
                 .or_else(|_| DefaultBranch::try_get_default())?,
             choose,
             all,
+            separate,
         })
     }
 }


### PR DESCRIPTION
To avoid two options with the short `-s` flag, this commit renames `--since` to `--base`. This seems to have a more consistent meaning within git projects.

Add a `--separate` flag that does not group any commits, not even commits sharing the same issue footer. This can be useful if you want to split apart one feature into multiple PRs, for example when different code-owners are involved.