### PR TITLE
feat: implement overlay

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -37,6 +37,15 @@ pub(crate) struct Args {
     )]
     pub choose: bool,
 
+    /// Combine multiple issue groups into one PR.
+    ///
+    /// When this flag is active, git-disjoint will create only one PR.
+    ///
+    /// This can be useful when you have multiple commits with no footer that
+    /// would be better reviewed or merged together.
+    #[clap(short, long, help = "Combine multiple issue groups into one PR")]
+    pub overlay: bool,
+
     /// Do not group commits by issue.
     ///
     /// Treat each commit independently, regardless of issue footer. Each

--- a/src/sanitized_args.rs
+++ b/src/sanitized_args.rs
@@ -5,9 +5,10 @@ use crate::args::Args;
 use crate::default_branch::DefaultBranch;
 
 pub(crate) struct SanitizedArgs {
+    pub all: bool,
     pub base: DefaultBranch,
     pub choose: bool,
-    pub all: bool,
+    pub overlay: bool,
     pub separate: bool,
 }
 
@@ -22,12 +23,14 @@ impl TryFrom<Args> for SanitizedArgs {
 
     fn try_from(value: Args) -> Result<Self, Self::Error> {
         let Args {
+            all,
             base,
             choose,
-            all,
+            overlay,
             separate,
         } = value;
         Ok(Self {
+            all,
             // Clap doesn't provide a way to supply a default value coming from
             // a function when the user has not supplied a required value.
             // This TryFrom bridges the gap.
@@ -36,7 +39,7 @@ impl TryFrom<Args> for SanitizedArgs {
                 .ok_or_else(|| anyhow!("User has not provided a default branch"))
                 .or_else(|_| DefaultBranch::try_get_default())?,
             choose,
-            all,
+            overlay,
             separate,
         })
     }


### PR DESCRIPTION
Closes #182

The `overlay` flag combines multiple issue groups into one PR.

This is a strange case for git-disjoint, a tool primarily designed
to separate changes into smaller PRs, to handle.

However, sometimes it is useful given underlying repository constraints.

When `overlay` is activated using the `--overlay` flag, the `choose`
menu prompts the user to select which issue-groups to combine into
a single PR.

When the `overlay` flag is active, git-disjoint is capable of making
only a single PR.